### PR TITLE
Fix submit button blocked by MIME type error

### DIFF
--- a/static/js/submit.js
+++ b/static/js/submit.js
@@ -1,3 +1,6 @@
+// Import Octokit from CDN
+import { Octokit } from 'https://cdn.skypack.dev/octokit@3';
+
 // GitHub OAuth Configuration
 // These values are passed from the Flask template via window.GITHUB_CONFIG
 const CONFIG = {
@@ -60,7 +63,7 @@ function initializeAuth() {
  */
 async function initializeOctokit(token) {
     try {
-        octokit = new Octokit.Octokit({ auth: token });
+        octokit = new Octokit({ auth: token });
 
         // Get user data
         const { data } = await octokit.rest.users.getAuthenticated();

--- a/templates/submit.html
+++ b/templates/submit.html
@@ -224,7 +224,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/@octokit/core@5.0.0/dist/bundle.min.js"></script>
 <script>
     // Pass configuration from Flask to JavaScript
     window.GITHUB_CONFIG = {
@@ -232,5 +231,5 @@
         callbackEndpoint: '{{ oauth_callback_endpoint }}'
     };
 </script>
-<script src="/static/js/submit.js"></script>
+<script type="module" src="/static/js/submit.js"></script>
 {% endblock %}


### PR DESCRIPTION
The previous CDN URL (@octokit/core@5.0.0/dist/bundle.min.js) was serving with incorrect MIME type (text/plain), causing the script to fail loading.

Changes:
- Convert to ES module imports using Skypack CDN
- Update submit.js to import Octokit as ES module
- Change Octokit instantiation from Octokit.Octokit to just Octokit
- Add type="module" to script tag in submit.html

This fixes the "MIME type mismatch" error in the browser console.