### PR TITLE
Add GitHub login integration

### DIFF
--- a/static/js/submit.js
+++ b/static/js/submit.js
@@ -129,12 +129,17 @@ function handleGitHubLogin() {
         return;
     }
 
+    if (!CONFIG.callbackEndpoint) {
+        showAuthError('OAuth callback endpoint is not configured. Please see the documentation for setup instructions.');
+        return;
+    }
+
     const state = generateRandomState();
     sessionStorage.setItem('oauth_state', state);
 
     const authUrl = new URL('https://github.com/login/oauth/authorize');
     authUrl.searchParams.set('client_id', CONFIG.clientId);
-    authUrl.searchParams.set('redirect_uri', CONFIG.redirectUri);
+    authUrl.searchParams.set('redirect_uri', CONFIG.callbackEndpoint);
     authUrl.searchParams.set('scope', CONFIG.scope);
     authUrl.searchParams.set('state', state);
 


### PR DESCRIPTION
The OAuth flow was incorrectly using the dctech.events/submit/ URL as the redirect_uri, but it should use the add.dctech.events/oauth/callback endpoint to properly exchange the authorization code for an access token.

This change updates the JavaScript to use CONFIG.callbackEndpoint instead of CONFIG.redirectUri for the OAuth redirect_uri parameter, and adds validation to ensure the callback endpoint is configured.