### PR TITLE
Fix GitHub login authentication issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run aggregator and build site
         env:
-          GITHUB_CLIENT_ID: ${{ vars.MY_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_ID: ${{ vars.GITHUB_CLIENT_ID }}
         run: |
           make all
 


### PR DESCRIPTION
The workflow was referencing vars.MY_GITHUB_CLIENT_ID but the variable should be vars.GITHUB_CLIENT_ID to match the expected repository variable name. This was causing the GITHUB_CLIENT_ID environment variable to be empty during the build, resulting in the "oauth_not_configured" error on the submit page.