### PR TITLE
Configure GitHub OAuth authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run aggregator and build site
         env:
-          GITHUB_CLIENT_ID: ${{ vars.GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_ID: ${{ vars.MY_GITHUB_CLIENT_ID }}
         run: |
           make all
 


### PR DESCRIPTION
The previous commit changed from vars.MY_GITHUB_CLIENT_ID to vars.GITHUB_CLIENT_ID, but the actual GitHub repository variable is named MY_GITHUB_CLIENT_ID.

This was causing the GITHUB_CLIENT_ID environment variable to be empty during the build, which resulted in the GitHub OAuth configuration not being included in the generated static site.

Reverting to use the correct variable name that exists in the repository settings.