### PR TITLE
Create group submission page for users

### DIFF
--- a/app.py
+++ b/app.py
@@ -867,6 +867,18 @@ def submit():
                           github_client_id=github_client_id,
                           oauth_callback_endpoint=oauth_callback_endpoint)
 
+@app.route("/submit-group/")
+def submit_group():
+    """Group submission page with GitHub OAuth"""
+    # Get OAuth configuration from environment or config
+    github_client_id = os.environ.get('GITHUB_CLIENT_ID', config.get('github_client_id', ''))
+    oauth_callback_endpoint = os.environ.get('OAUTH_CALLBACK_ENDPOINT',
+                                            config.get('oauth_callback_endpoint', ''))
+
+    return render_template('submit-group.html',
+                          github_client_id=github_client_id,
+                          oauth_callback_endpoint=oauth_callback_endpoint)
+
 @app.route("/sitemap.xml")
 def sitemap():
     """Generate an XML sitemap of the site's main pages"""

--- a/build.js
+++ b/build.js
@@ -12,7 +12,8 @@ if (!fs.existsSync(outDir)) {
   fs.mkdirSync(outDir, { recursive: true });
 }
 
-const buildOptions = {
+// Build options for event submission
+const submitBuildOptions = {
   entryPoints: ['static/js/submit.js'],
   bundle: true,
   minify: true,
@@ -23,14 +24,33 @@ const buildOptions = {
   logLevel: 'info'
 };
 
+// Build options for group submission
+const submitGroupBuildOptions = {
+  entryPoints: ['static/js/submit-group.js'],
+  bundle: true,
+  minify: true,
+  sourcemap: true,
+  format: 'esm',
+  target: ['es2020'],
+  outfile: 'static/js/dist/submit-group.bundle.js',
+  logLevel: 'info'
+};
+
 async function build() {
   try {
     if (isWatch) {
-      const context = await esbuild.context(buildOptions);
-      await context.watch();
+      const submitContext = await esbuild.context(submitBuildOptions);
+      const submitGroupContext = await esbuild.context(submitGroupBuildOptions);
+      await Promise.all([
+        submitContext.watch(),
+        submitGroupContext.watch()
+      ]);
       console.log('Watching for changes...');
     } else {
-      await esbuild.build(buildOptions);
+      await Promise.all([
+        esbuild.build(submitBuildOptions),
+        esbuild.build(submitGroupBuildOptions)
+      ]);
       console.log('Build completed successfully!');
     }
   } catch (error) {

--- a/static/js/submit-group.js
+++ b/static/js/submit-group.js
@@ -1,0 +1,410 @@
+// Import Octokit from npm package
+import { Octokit } from 'octokit';
+
+// GitHub OAuth Configuration
+// These values are passed from the Flask template via window.GITHUB_CONFIG
+const CONFIG = {
+    clientId: window.GITHUB_CONFIG?.clientId || '',
+    redirectUri: window.location.origin + '/submit-group/', // OAuth will redirect back here
+    scope: 'public_repo',
+    // The OAuth callback endpoint in add.dctech.events
+    callbackEndpoint: window.GITHUB_CONFIG?.callbackEndpoint || ''
+};
+
+// Repository configuration
+const REPO_CONFIG = {
+    owner: 'rosskarchner',
+    repo: 'dctech.events',
+    branch: 'main',
+    targetDir: '_groups'
+};
+
+// State management
+let octokit = null;
+let userData = null;
+
+// Initialize on page load
+function initialize() {
+    initializeAuth();
+    setupEventListeners();
+}
+
+// Handle both cases: DOM already loaded or still loading
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialize);
+} else {
+    // DOM already loaded, initialize immediately
+    initialize();
+}
+
+/**
+ * Initialize authentication state
+ */
+function initializeAuth() {
+    // Check for OAuth callback
+    const urlParams = new URLSearchParams(window.location.search);
+    const accessToken = urlParams.get('access_token');
+    const error = urlParams.get('error');
+
+    if (error) {
+        showAuthError('Authentication failed: ' + error);
+        return;
+    }
+
+    if (accessToken) {
+        // Store token and clean URL
+        sessionStorage.setItem('github_token', accessToken);
+        window.history.replaceState({}, document.title, window.location.pathname);
+        initializeOctokit(accessToken);
+        return;
+    }
+
+    // Check for existing token
+    const storedToken = sessionStorage.getItem('github_token');
+    if (storedToken) {
+        initializeOctokit(storedToken);
+    }
+}
+
+/**
+ * Initialize Octokit with access token
+ */
+async function initializeOctokit(token) {
+    try {
+        octokit = new Octokit({ auth: token });
+
+        // Get user data
+        const { data } = await octokit.rest.users.getAuthenticated();
+        userData = data;
+
+        // Update UI
+        showAuthenticatedState();
+    } catch (error) {
+        console.error('Authentication error:', error);
+        sessionStorage.removeItem('github_token');
+        showAuthError('Failed to authenticate with GitHub');
+    }
+}
+
+/**
+ * Set up event listeners
+ */
+function setupEventListeners() {
+    const githubLoginBtn = document.getElementById('github-login');
+    const groupForm = document.getElementById('group-form');
+    const cancelBtn = document.getElementById('cancel-btn');
+    const submitAnotherBtn = document.getElementById('submit-another');
+
+    if (githubLoginBtn) {
+        githubLoginBtn.addEventListener('click', handleGitHubLogin);
+    } else {
+        console.error('GitHub login button not found');
+    }
+
+    if (groupForm) {
+        groupForm.addEventListener('submit', handleFormSubmit);
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', resetForm);
+    }
+
+    if (submitAnotherBtn) {
+        submitAnotherBtn.addEventListener('click', () => {
+            document.getElementById('success-message').style.display = 'none';
+            resetForm();
+        });
+    }
+}
+
+/**
+ * Handle GitHub login
+ */
+function handleGitHubLogin() {
+    // For now, we'll use a direct OAuth flow
+    // In production, this should go through the add.dctech.events OAuth handler
+
+    if (!CONFIG.clientId) {
+        showAuthError('GitHub OAuth is not configured. Please see the documentation for setup instructions.');
+        return;
+    }
+
+    if (!CONFIG.callbackEndpoint) {
+        showAuthError('OAuth callback endpoint is not configured. Please see the documentation for setup instructions.');
+        return;
+    }
+
+    const state = generateRandomState();
+    sessionStorage.setItem('oauth_state', state);
+
+    const authUrl = new URL('https://github.com/login/oauth/authorize');
+    authUrl.searchParams.set('client_id', CONFIG.clientId);
+    authUrl.searchParams.set('redirect_uri', CONFIG.callbackEndpoint);
+    authUrl.searchParams.set('scope', CONFIG.scope);
+    authUrl.searchParams.set('state', state);
+
+    // Redirect to GitHub OAuth
+    window.location.href = authUrl.toString();
+}
+
+/**
+ * Show authenticated state
+ */
+function showAuthenticatedState() {
+    const authStatus = document.getElementById('auth-status');
+    authStatus.className = 'auth-status authenticated';
+    authStatus.innerHTML = `
+        <p>✓ Signed in as <strong>${userData.login}</strong></p>
+        <button id="sign-out" class="btn btn-secondary">Sign Out</button>
+    `;
+
+    document.getElementById('sign-out').addEventListener('click', handleSignOut);
+    document.getElementById('group-form').style.display = 'block';
+    document.getElementById('auth-section').querySelector('p').style.display = 'none';
+}
+
+/**
+ * Handle sign out
+ */
+function handleSignOut() {
+    sessionStorage.removeItem('github_token');
+    octokit = null;
+    userData = null;
+    window.location.reload();
+}
+
+/**
+ * Handle form submission
+ */
+async function handleFormSubmit(e) {
+    e.preventDefault();
+
+    if (!octokit || !userData) {
+        showError('You must be signed in to submit a group');
+        return;
+    }
+
+    const submitBtn = document.getElementById('submit-btn');
+    const statusMessage = document.getElementById('status-message');
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Submitting...';
+    statusMessage.className = 'status-message info';
+    statusMessage.textContent = 'Creating pull request...';
+    statusMessage.style.display = 'block';
+
+    try {
+        // Collect form data
+        const formData = {
+            name: document.getElementById('name').value.trim(),
+            website: document.getElementById('website').value.trim(),
+            ical: document.getElementById('ical').value.trim() || '',
+            rss: document.getElementById('rss').value.trim() || '',
+            fallback_url: document.getElementById('fallback_url').value.trim() || '',
+            submitter_link: document.getElementById('submitter_link').value.trim() || '',
+            submitted_by: userData.login
+        };
+
+        // Validate data
+        if (!formData.name || !formData.website) {
+            throw new Error('Please fill in all required fields');
+        }
+
+        // Create the PR
+        const prUrl = await createPullRequest(formData);
+
+        // Show success
+        showSuccess(prUrl);
+
+    } catch (error) {
+        console.error('Submission error:', error);
+        showError(error.message || 'Failed to submit group. Please try again.');
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Submit Group';
+    }
+}
+
+/**
+ * Create a pull request with the group data
+ */
+async function createPullRequest(groupData) {
+    // Step 1: Check if user has a fork, create one if needed
+    let forkExists = false;
+    try {
+        // Try to get the existing fork
+        await octokit.rest.repos.get({
+            owner: userData.login,
+            repo: REPO_CONFIG.repo
+        });
+        forkExists = true;
+    } catch (error) {
+        if (error.status === 404) {
+            // Fork doesn't exist, create it
+            const statusMessage = document.getElementById('status-message');
+            statusMessage.textContent = 'Creating a fork of the repository...';
+
+            await octokit.rest.repos.createFork({
+                owner: REPO_CONFIG.owner,
+                repo: REPO_CONFIG.repo
+            });
+
+            // Wait for fork to be ready. GitHub's fork creation is async.
+            // A more robust solution would poll the fork status, but a 3-second
+            // delay is sufficient for most cases and keeps the implementation simple.
+            // If the fork isn't ready in 3 seconds (rare), the subsequent branch
+            // creation will fail with a clear error that the user can retry.
+            statusMessage.textContent = 'Waiting for fork to be ready...';
+            await new Promise(resolve => setTimeout(resolve, 3000));
+
+            statusMessage.textContent = 'Creating pull request...';
+        } else {
+            throw error;
+        }
+    }
+
+    // Step 2: Get the default branch ref from the upstream repo
+    const { data: mainBranch } = await octokit.rest.repos.getBranch({
+        owner: REPO_CONFIG.owner,
+        repo: REPO_CONFIG.repo,
+        branch: REPO_CONFIG.branch
+    });
+
+    const mainSha = mainBranch.commit.sha;
+
+    // Step 3: Create a new branch in the user's fork
+    const branchName = `group-submission-${Date.now()}`;
+    await octokit.rest.git.createRef({
+        owner: userData.login,
+        repo: REPO_CONFIG.repo,
+        ref: `refs/heads/${branchName}`,
+        sha: mainSha
+    });
+
+    // Step 4: Create YAML content
+    const yamlContent = generateYAML(groupData);
+    const fileName = `${slugify(groupData.name)}.yaml`;
+    const filePath = `${REPO_CONFIG.targetDir}/${fileName}`;
+
+    // Step 5: Create file in the new branch of the fork
+    await octokit.rest.repos.createOrUpdateFileContents({
+        owner: userData.login,
+        repo: REPO_CONFIG.repo,
+        path: filePath,
+        message: `Add group: ${groupData.name}`,
+        content: btoa(yamlContent), // Base64 encode
+        branch: branchName
+    });
+
+    // Step 6: Create pull request from fork to upstream
+    const { data: pr } = await octokit.rest.pulls.create({
+        owner: REPO_CONFIG.owner,
+        repo: REPO_CONFIG.repo,
+        title: `Add group: ${groupData.name}`,
+        head: `${userData.login}:${branchName}`,
+        base: REPO_CONFIG.branch,
+        body: `## Group Submission
+
+**Name:** ${groupData.name}
+**Website:** ${groupData.website}
+${groupData.ical ? `**iCal Feed:** ${groupData.ical}\n` : ''}${groupData.rss ? `**RSS Feed:** ${groupData.rss}\n` : ''}${groupData.fallback_url ? `**Fallback URL:** ${groupData.fallback_url}\n` : ''}${groupData.submitter_link ? `**Submitted by:** ${groupData.submitter_link}\n` : ''}
+
+This group was submitted via the web form by @${groupData.submitted_by}.`
+    });
+
+    return pr.html_url;
+}
+
+/**
+ * Generate YAML content from group data
+ */
+function generateYAML(data) {
+    let yaml = `name: ${data.name}\n`;
+    yaml += `website: ${data.website}\n`;
+    if (data.ical) {
+        yaml += `ical: ${data.ical}\n`;
+    }
+    if (data.rss) {
+        yaml += `rss: ${data.rss}\n`;
+    }
+    if (data.fallback_url) {
+        yaml += `fallback_url: ${data.fallback_url}\n`;
+    }
+    yaml += `active: true\n`;
+
+    return yaml;
+}
+
+/**
+ * Convert string to URL-safe slug
+ */
+function slugify(text) {
+    return text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/[\s_-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .substring(0, 50); // Limit length
+}
+
+/**
+ * Show error message in the auth section (visible area)
+ */
+function showAuthError(message) {
+    const authStatus = document.getElementById('auth-status');
+
+    // Create or update error message element
+    let errorDiv = authStatus.querySelector('.auth-error');
+    if (!errorDiv) {
+        errorDiv = document.createElement('div');
+        errorDiv.className = 'auth-error';
+        authStatus.appendChild(errorDiv);
+    }
+
+    errorDiv.textContent = '⚠ ' + message;
+    errorDiv.style.display = 'block';
+    errorDiv.style.marginTop = 'var(--spacing-md)';
+    errorDiv.style.padding = 'var(--spacing-md)';
+    errorDiv.style.backgroundColor = '#fef2f2';
+    errorDiv.style.border = '1px solid #fca5a5';
+    errorDiv.style.borderRadius = 'var(--border-radius)';
+    errorDiv.style.color = '#991b1b';
+}
+
+/**
+ * Show error message
+ */
+function showError(message) {
+    const statusMessage = document.getElementById('status-message');
+    statusMessage.className = 'status-message error';
+    statusMessage.textContent = '⚠ ' + message;
+    statusMessage.style.display = 'block';
+}
+
+/**
+ * Show success message with PR link
+ */
+function showSuccess(prUrl) {
+    document.getElementById('group-form').style.display = 'none';
+    document.getElementById('success-message').style.display = 'block';
+
+    const prLink = document.getElementById('pr-link');
+    prLink.href = prUrl;
+    prLink.textContent = prUrl;
+}
+
+/**
+ * Reset form
+ */
+function resetForm() {
+    document.getElementById('group-form').reset();
+    document.getElementById('status-message').style.display = 'none';
+    document.getElementById('group-form').style.display = 'block';
+}
+
+/**
+ * Generate random state for OAuth
+ */
+function generateRandomState() {
+    return Math.random().toString(36).substring(2, 15) +
+           Math.random().toString(36).substring(2, 15);
+}

--- a/templates/submit-group.html
+++ b/templates/submit-group.html
@@ -1,0 +1,302 @@
+{% extends "base.html" %}
+
+{% block title %}Submit a Group - {{ site_name }}{% endblock %}
+
+{% block content %}
+<div class="submit-container">
+    <h2>Submit a Group to DC Tech Events</h2>
+
+    <div id="auth-section">
+        <p>To submit a group, you'll need to sign in with your GitHub account. This allows us to create a pull request on your behalf to add your group to the calendar.</p>
+
+        <div class="auth-status" id="auth-status">
+            <p>Not signed in</p>
+            <button id="github-login" class="btn btn-primary">
+                <svg height="16" width="16" viewBox="0 0 16 16" style="vertical-align: text-bottom; margin-right: 8px;">
+                    <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                Sign in with GitHub
+            </button>
+        </div>
+    </div>
+
+    <form id="group-form" style="display: none;">
+        <div class="group-section">
+            <h3>Group Details</h3>
+
+            <div class="form-group">
+                <label for="name">Group Name <span class="required">*</span></label>
+                <input type="text" id="name" name="name" required maxlength="200"
+                       placeholder="e.g., DC Python User Group">
+            </div>
+
+            <div class="form-group">
+                <label for="website">Group Website <span class="required">*</span></label>
+                <input type="url" id="website" name="website" required
+                       placeholder="https://example.com or https://meetup.com/your-group">
+                <small>Main website or Meetup.com page for your group</small>
+            </div>
+
+            <div class="form-group">
+                <label for="ical">iCal Feed URL</label>
+                <input type="url" id="ical" name="ical"
+                       placeholder="https://example.com/calendar.ics">
+                <small>Calendar feed URL (iCal format) - at least one feed type is recommended</small>
+            </div>
+
+            <div class="form-group">
+                <label for="rss">RSS Feed URL</label>
+                <input type="url" id="rss" name="rss"
+                       placeholder="https://example.com/events/rss or https://www.meetup.com/your-group/events/rss">
+                <small>RSS feed URL for events - at least one feed type is recommended</small>
+            </div>
+
+            <details class="optional-details">
+                <summary>Optional Details</summary>
+                <div class="optional-fields">
+                    <div class="form-group">
+                        <label for="fallback_url">Fallback URL</label>
+                        <input type="url" id="fallback_url" name="fallback_url"
+                               placeholder="https://example.com/events">
+                        <small>Alternative URL to find events if feeds are unavailable</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="submitter_link">Your Link</label>
+                        <input type="url" id="submitter_link" name="submitter_link"
+                               placeholder="https://yoursite.com">
+                        <small>Link to your website or social profile</small>
+                    </div>
+                </div>
+            </details>
+        </div>
+
+        <div id="status-message" class="status-message"></div>
+
+        <div class="form-actions">
+            <button type="submit" id="submit-btn" class="btn btn-primary">
+                Submit Group
+            </button>
+            <button type="button" id="cancel-btn" class="btn btn-secondary">
+                Cancel
+            </button>
+        </div>
+    </form>
+
+    <div id="success-message" style="display: none;">
+        <div class="success-box">
+            <h3>✓ Pull Request Created!</h3>
+            <p>Your group has been submitted successfully. A pull request has been created:</p>
+            <p><a id="pr-link" target="_blank" rel="noopener noreferrer"></a></p>
+            <p>Once reviewed and merged, your group's events will appear on the calendar.</p>
+            <button id="submit-another" class="btn btn-primary">Submit Another Group</button>
+        </div>
+    </div>
+</div>
+
+<style>
+.submit-container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.submit-container h2 {
+    margin-bottom: var(--spacing-lg);
+}
+
+.group-section {
+    border: 1px solid var(--color-border);
+    border-radius: 5px;
+    padding: 20px;
+    margin-bottom: var(--spacing-lg);
+}
+
+.group-section h3 {
+    margin-top: 0;
+    margin-bottom: var(--spacing-lg);
+    font-size: 1.25rem;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-lg);
+}
+
+@media (max-width: 640px) {
+    .form-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+.form-group {
+    margin-bottom: var(--spacing-lg);
+}
+
+.form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: var(--spacing-sm);
+    color: var(--color-text);
+}
+
+.form-group label .required {
+    color: #dc2626;
+    font-weight: bold;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+    width: 100%;
+    padding: var(--spacing-sm);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    font-size: 1rem;
+    font-family: inherit;
+    box-sizing: border-box;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-group small {
+    display: block;
+    margin-top: var(--spacing-xs);
+    color: var(--color-text-light);
+    font-size: 0.875rem;
+}
+
+.optional-details {
+    margin-top: var(--spacing-lg);
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--spacing-lg);
+}
+
+.optional-details summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-primary);
+    padding: var(--spacing-sm) 0;
+    list-style-position: inside;
+}
+
+.optional-details summary:hover {
+    color: var(--color-primary-hover);
+}
+
+.optional-fields {
+    padding-top: var(--spacing-lg);
+}
+
+.btn {
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border: none;
+    border-radius: var(--border-radius);
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+}
+
+.btn-primary {
+    background-color: var(--color-primary);
+    color: white;
+}
+
+.btn-primary:hover {
+    background-color: var(--color-primary-hover);
+}
+
+.btn-primary:disabled {
+    background-color: var(--color-text-lighter);
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    background-color: var(--color-background-alt);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+}
+
+.btn-secondary:hover {
+    background-color: var(--color-border);
+}
+
+.form-actions {
+    display: flex;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-xl);
+}
+
+.auth-status {
+    padding: var(--spacing-lg);
+    background-color: var(--color-background-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    margin: var(--spacing-lg) 0;
+}
+
+.auth-status.authenticated {
+    background-color: #f0fdf4;
+    border-color: #86efac;
+}
+
+.status-message {
+    padding: var(--spacing-md);
+    border-radius: var(--border-radius);
+    margin-bottom: var(--spacing-md);
+    display: none;
+}
+
+.status-message.error {
+    display: block;
+    background-color: #fef2f2;
+    border: 1px solid #fca5a5;
+    color: #991b1b;
+}
+
+.status-message.info {
+    display: block;
+    background-color: #eff6ff;
+    border: 1px solid #93c5fd;
+    color: #1e40af;
+}
+
+.success-box {
+    padding: var(--spacing-xl);
+    background-color: #f0fdf4;
+    border: 2px solid #86efac;
+    border-radius: var(--border-radius);
+}
+
+.success-box h3 {
+    color: #166534;
+    margin-top: 0;
+}
+
+.success-box a {
+    color: var(--color-primary);
+    word-break: break-all;
+}
+</style>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    // Pass configuration from Flask to JavaScript
+    window.GITHUB_CONFIG = {
+        clientId: '{{ github_client_id }}',
+        callbackEndpoint: '{{ oauth_callback_endpoint }}'
+    };
+</script>
+<script type="module" src="/static/js/dist/submit-group.bundle.js"></script>
+{% endblock %}


### PR DESCRIPTION
Implements a new /submit-group/ page that allows users to submit groups to the DC Tech Events calendar via pull request. The implementation mirrors the existing event submission workflow:

- New template: templates/submit-group.html
- New JavaScript module: static/js/submit-group.js
- Flask route: /submit-group/
- GitHub OAuth integration using same credentials as event submission
- Client-side PR creation using Octokit.js
- Creates YAML files in _groups/ directory
- Updated build.js to bundle both submission pages

Group submissions require:
- Group name (required)
- Website URL (required)
- iCal or RSS feed (optional but recommended)
- Fallback URL (optional)