### PR TITLE
Fix group addition references in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The generated site will be in the `build/` directory.
 
 ### Adding a Group
 
-Create a new YAML file in the `_groups/` directory with the following format:
+You can submit a group through the [/submit-group/](/submit-group/) page, which creates a pull request for you.
+
+Alternatively, you can manually create a new YAML file in the `_groups/` directory with the following format:
 
 ```yaml
 name: Group Name

--- a/templates/approved_groups_list.html
+++ b/templates/approved_groups_list.html
@@ -6,8 +6,8 @@
 <h1>Tech Groups in DC</h1>
 <div class="groups-container">
 <div class="suggest-group">
-    <p>Don't see your group? 
-        <a href="https://github.com/rosskarchner/dctech.events/issues">Open an issue</a> or <a href="https://add.dctech.events/dctech">submit here</a>.
+    <p>Don't see your group?
+        <a href="https://github.com/rosskarchner/dctech.events/issues">Open an issue</a> or <a href="/submit-group/">submit here</a>.
     </p>
 </div>
 


### PR DESCRIPTION
- Changed link in approved_groups_list.html from external URL to /submit-group/
- Updated README.md to mention the new /submit-group/ page as the primary method
- Kept manual YAML file creation as an alternative method in README