### PR TITLE
Fix redirect after login on submit page

### DIFF
--- a/static/js/submit-group.js
+++ b/static/js/submit-group.js
@@ -134,8 +134,13 @@ function handleGitHubLogin() {
         return;
     }
 
-    const state = generateRandomState();
-    sessionStorage.setItem('oauth_state', state);
+    // Create state object with CSRF token and return URL
+    const stateObj = {
+        csrf: generateRandomState(),
+        returnUrl: window.location.pathname
+    };
+    const state = btoa(JSON.stringify(stateObj)); // Base64 encode the state object
+    sessionStorage.setItem('oauth_state', stateObj.csrf);
 
     const authUrl = new URL('https://github.com/login/oauth/authorize');
     authUrl.searchParams.set('client_id', CONFIG.clientId);

--- a/static/js/submit.js
+++ b/static/js/submit.js
@@ -134,8 +134,13 @@ function handleGitHubLogin() {
         return;
     }
 
-    const state = generateRandomState();
-    sessionStorage.setItem('oauth_state', state);
+    // Create state object with CSRF token and return URL
+    const stateObj = {
+        csrf: generateRandomState(),
+        returnUrl: window.location.pathname
+    };
+    const state = btoa(JSON.stringify(stateObj)); // Base64 encode the state object
+    sessionStorage.setItem('oauth_state', stateObj.csrf);
 
     const authUrl = new URL('https://github.com/login/oauth/authorize');
     authUrl.searchParams.set('client_id', CONFIG.clientId);


### PR DESCRIPTION
The OAuth callback was hardcoded to redirect to /submit/ after authentication, causing users who logged in from /submit-group/ to be redirected to the wrong page.

This change encodes the return URL (pathname) in the OAuth state parameter as a base64-encoded JSON object containing both the CSRF token and the return URL. The OAuth callback handler can then decode the state and redirect users back to the correct page (/submit/ or /submit-group/) after authentication.

Changes:
- Updated submit.js and submit-group.js to encode return URL in state parameter
- Updated OAUTH_SETUP.md to document the new state parameter format and callback logic