### PR TITLE
Fix GitHub sign-in redirect issue

### DIFF
--- a/oauth-endpoint/app.py
+++ b/oauth-endpoint/app.py
@@ -119,8 +119,12 @@ def oauth_callback():
     city = state_data['city'] if state_data else 'dc'
 
     # Build base URL for redirect
-    # Use dc.localtech.events for dc, otherwise {city}.localtech.events
-    base_url = f'https://{city}.localtech.events'
+    # Map city slugs to their actual domains
+    # DC uses dctech.events (legacy domain), other cities use {city}.localtech.events
+    if city == 'dc':
+        base_url = 'https://dctech.events'
+    else:
+        base_url = f'https://{city}.localtech.events'
 
     # Handle errors
     if error:


### PR DESCRIPTION
The OAuth callback was redirecting DC users to https://dc.localtech.events/submit/ which doesn't exist yet. Updated the callback to redirect to https://dctech.events for the DC city while maintaining the {city}.localtech.events pattern for future cities.

Fixes: GitHub signin now redirects to the correct domain after authentication.