### PR TITLE
Debug and fix recent failure

### DIFF
--- a/refresh_calendars.py
+++ b/refresh_calendars.py
@@ -452,17 +452,19 @@ def main():
     os.makedirs(CACHE_DIR, exist_ok=True)
     os.makedirs(ICAL_CACHE_DIR, exist_ok=True)
     os.makedirs(DATA_DIR, exist_ok=True)
-    
+
     # Always check and update the current day file
+    day_file_updated = False
     if not is_current_day_file_updated():
         print("Current day file is out of date, updating...")
         update_current_day_file()
-    
+        day_file_updated = True
+
     # Run the refresh
     updated = refresh_calendars()
-    
-    # Return exit code based on whether calendars were updated
-    return 0 if updated else 1
+
+    # Return exit code based on whether calendars were updated OR day file was updated
+    return 0 if (updated or day_file_updated) else 1
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
The script was exiting with code 1 even when successfully updating the current day file. This happened because:

1. main() would update the day file if out of date
2. refresh_calendars() would then check if day file is out of date, but it was already updated, so it would return False
3. main() would return exit code 1 even though work was done

Now we track whether the day file was updated and return exit code 0 if either the day file or calendars were updated.

Fixes the "make: *** [Makefile:15: refresh-calendars] Error 1" issue when building Baltimore site.