### PR TITLE
Deploy application to production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ freeze: generate-month-data
 	python freeze.py --city $(CITY)
 
 # Build localtech.events homepage
-homepage:
+homepage: js-build
 	python freeze.py --homepage
 
 # Validation targets


### PR DESCRIPTION
The homepage target in Makefile was not running js-build before freezing, which meant JavaScript bundle files (submit.bundle.js, submit-group.bundle.js) were not being created when building the homepage. This caused deployed sites to be missing these files.

This fix adds js-build as a dependency of the homepage target, ensuring bundles are built before the homepage is frozen.

Fixes missing file: /static/js/dist/submit.bundle.js