### PR TITLE
Investigate and diagnose code issue

### DIFF
--- a/refresh_calendars.py
+++ b/refresh_calendars.py
@@ -463,8 +463,9 @@ def main():
     # Run the refresh
     updated = refresh_calendars()
 
-    # Return exit code based on whether calendars were updated OR day file was updated
-    return 0 if (updated or day_file_updated) else 1
+    # Always return success (0) - "no updates needed" is a successful state
+    # Only errors (exceptions) should cause non-zero exit codes
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
The script was returning exit code 1 when no calendar updates were needed, causing make builds to fail even when everything was working correctly.

Changed to always return exit code 0 (success) since "no updates needed" is a valid successful state. Only actual errors (exceptions) should cause non-zero exit codes.