### PR TITLE
Fix GitHub login redirect issue

### DIFF
--- a/static/js/submit-group.js
+++ b/static/js/submit-group.js
@@ -162,12 +162,12 @@ function handleGitHubLogin() {
 
     // Create state object with CSRF token, return URL, and city
     const stateObj = {
-        csrf: generateRandomState(),
-        returnUrl: window.location.pathname,
+        csrf_token: generateRandomState(),
+        return_url: window.location.pathname,
         city: getSelectedCity()
     };
     const state = btoa(JSON.stringify(stateObj)); // Base64 encode the state object
-    sessionStorage.setItem('oauth_state', stateObj.csrf);
+    sessionStorage.setItem('oauth_state', stateObj.csrf_token);
 
     const authUrl = new URL('https://github.com/login/oauth/authorize');
     authUrl.searchParams.set('client_id', CONFIG.clientId);

--- a/static/js/submit.js
+++ b/static/js/submit.js
@@ -162,12 +162,12 @@ function handleGitHubLogin() {
 
     // Create state object with CSRF token, return URL, and city
     const stateObj = {
-        csrf: generateRandomState(),
-        returnUrl: window.location.pathname,
+        csrf_token: generateRandomState(),
+        return_url: window.location.pathname,
         city: getSelectedCity()
     };
     const state = btoa(JSON.stringify(stateObj)); // Base64 encode the state object
-    sessionStorage.setItem('oauth_state', stateObj.csrf);
+    sessionStorage.setItem('oauth_state', stateObj.csrf_token);
 
     const authUrl = new URL('https://github.com/login/oauth/authorize');
     authUrl.searchParams.set('client_id', CONFIG.clientId);


### PR DESCRIPTION
Fixed OAuth state parameter field names to match backend expectations. The JavaScript was using 'csrf' and 'returnUrl' but the backend expects 'csrf_token' and 'return_url'. This caused state validation to fail, defaulting city to 'dc' and redirecting to dctech.events instead of the correct city domain (e.g., baltimore.localtech.events).

Fixes the issue where clicking "log in with Github" on baltimore.localtech.events/submit/ would redirect to dctech.events/submit/.