### PR TITLE
Migrate organize.dctech.events into next.dctech.events

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,14 +23,3 @@ oauth_callback_endpoint: "https://add.dctech.events/oauth/callback"
 # Token is set via GITHUB_SPONSORS_TOKEN environment variable
 # Used for sponsor verification during build
 github_sponsors_token: ""  # Set via GITHUB_SPONSORS_TOKEN environment variable
-
-# Organize DC Tech Events Integration
-# Feature flags to control when organize.dctech.events data appears on the main site
-organize_integration_enabled: false  # Set to true when ready to show organize.dctech.events content
-organize_groups_enabled: false       # Set to true to include groups from organize.dctech.events
-organize_events_enabled: false       # Set to true to include events from organize.dctech.events
-
-# URLs for fetching groups and events from organize.dctech.events
-# These can be CloudFront URLs or custom domain URLs
-organize_groups_url: "https://organize.dctech.events/groups.yaml"
-organize_events_url: "https://organize.dctech.events/events.yaml"

--- a/generate_month_data.py
+++ b/generate_month_data.py
@@ -11,7 +11,6 @@ import sys
 import calendar as cal_module
 import dateparser
 import json
-import urllib.request
 from address_utils import normalize_address
 
 # Load configuration
@@ -211,27 +210,9 @@ def event_to_dict(event, group=None):
         print(f"Error converting event to dictionary: {str(e)}")
         return None
 
-def fetch_organize_yaml(url):
-    """
-    Fetch YAML data from a URL
-
-    Args:
-        url: URL to fetch YAML from
-
-    Returns:
-        Dictionary of data from YAML, or empty dict if error
-    """
-    try:
-        with urllib.request.urlopen(url, timeout=10) as response:
-            data = response.read()
-            return yaml.safe_load(data) or {}
-    except Exception as e:
-        print(f"Warning: Could not fetch {url}: {str(e)}")
-        return {}
-
 def load_groups():
     """
-    Load all groups from the _groups directory AND organize.dctech.events
+    Load all groups from the _groups directory
 
     Returns:
         A list of group dictionaries
@@ -249,35 +230,11 @@ def load_groups():
         except Exception as e:
             print(f"Error loading group from {file_path}: {str(e)}")
 
-    # Fetch groups from organize.dctech.events (if enabled)
-    organize_enabled = config.get('organize_integration_enabled', False)
-    organize_groups_enabled = config.get('organize_groups_enabled', False)
-
-    if organize_enabled and organize_groups_enabled:
-        organize_groups_url = config.get('organize_groups_url',
-            'https://organize.dctech.events/groups.yaml')
-
-        print(f"Fetching groups from {organize_groups_url}...")
-        organize_groups = fetch_organize_yaml(organize_groups_url)
-
-        # Add groups from organize.dctech.events
-        for group_id, group_data in organize_groups.items():
-            if isinstance(group_data, dict):
-                group_data['id'] = group_id
-                group_data['source'] = 'organize'
-                groups.append(group_data)
-                print(f"Added group from organize.dctech.events: {group_data.get('name', group_id)}")
-    else:
-        if not organize_enabled:
-            print("organize.dctech.events integration is disabled (organize_integration_enabled=false)")
-        elif not organize_groups_enabled:
-            print("organize.dctech.events groups are disabled (organize_groups_enabled=false)")
-
     return groups
 
 def load_single_events():
     """
-    Load all single events from the _single_events directory AND organize.dctech.events
+    Load all single events from the _single_events directory
 
     Returns:
         A list of event dictionaries
@@ -419,42 +376,6 @@ def load_single_events():
                 events.append(event)
         except Exception as e:
             print(f"Error loading event from {file_path}: {str(e)}")
-
-    # Fetch events from organize.dctech.events (if enabled)
-    organize_enabled = config.get('organize_integration_enabled', False)
-    organize_events_enabled = config.get('organize_events_enabled', False)
-
-    if organize_enabled and organize_events_enabled:
-        organize_events_url = config.get('organize_events_url',
-            'https://organize.dctech.events/events.yaml')
-
-        print(f"Fetching events from {organize_events_url}...")
-        organize_events = fetch_organize_yaml(organize_events_url)
-
-        # Add events from organize.dctech.events
-        for event_id, event_data in organize_events.items():
-            if isinstance(event_data, dict):
-                event_data['id'] = event_id
-                event_data['source'] = 'organize'
-
-                # Normalize location if present
-                if 'location' in event_data:
-                    event_data['location'] = normalize_address(event_data['location'])
-
-                # Map submitted_by to submitter_name and submitter_link
-                if 'submitted_by' in event_data:
-                    if event_data['submitted_by'].lower() != 'anonymous':
-                        event_data['submitter_name'] = event_data['submitted_by']
-                        if 'submitter_link' in event_data:
-                            event_data['submitter_link'] = event_data['submitter_link']
-
-                events.append(event_data)
-                print(f"Added event from organize.dctech.events: {event_data.get('title', event_id)}")
-    else:
-        if not organize_enabled:
-            print("organize.dctech.events integration is disabled (organize_integration_enabled=false)")
-        elif not organize_events_enabled:
-            print("organize.dctech.events events are disabled (organize_events_enabled=false)")
 
     return events
 

--- a/infrastructure/frontend/static/css/organize.css
+++ b/infrastructure/frontend/static/css/organize.css
@@ -1,0 +1,321 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f5;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  background-color: #2c3e50;
+  color: white;
+  padding: 20px 0;
+  margin-bottom: 30px;
+}
+
+header h1 {
+  margin-bottom: 15px;
+}
+
+nav {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+nav a, nav button {
+  color: white;
+  text-decoration: none;
+  padding: 8px 15px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+nav a:hover, nav button:hover {
+  background-color: #34495e;
+}
+
+nav a.active {
+  background-color: #3498db;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  text-decoration: none;
+  transition: background-color 0.2s;
+}
+
+.btn-primary {
+  background-color: #3498db;
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: #2980b9;
+}
+
+.btn-secondary {
+  background-color: #95a5a6;
+  color: white;
+}
+
+.btn-secondary:hover {
+  background-color: #7f8c8d;
+}
+
+.btn-danger {
+  background-color: #e74c3c;
+  color: white;
+}
+
+.btn-danger:hover {
+  background-color: #c0392b;
+}
+
+.btn-small {
+  padding: 5px 10px;
+  font-size: 14px;
+}
+
+.card {
+  background-color: white;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.card h2, .card h3 {
+  margin-bottom: 15px;
+  color: #2c3e50;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 500;
+  color: #2c3e50;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+  font-family: inherit;
+}
+
+.form-group textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 5px;
+  color: #7f8c8d;
+  font-size: 14px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.event-card,
+.group-card {
+  background-color: white;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s;
+}
+
+.event-card:hover,
+.group-card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.event-card h3,
+.group-card h3 {
+  margin-bottom: 10px;
+  color: #2c3e50;
+}
+
+.event-date {
+  color: #3498db;
+  font-weight: 500;
+  margin-bottom: 5px;
+}
+
+.event-location,
+.group-website {
+  color: #7f8c8d;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.message {
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 4px;
+}
+
+.message.error {
+  background-color: #fadbd8;
+  color: #c0392b;
+  border: 1px solid #e74c3c;
+}
+
+.message.success {
+  background-color: #d5f4e6;
+  color: #27ae60;
+  border: 1px solid #2ecc71;
+}
+
+.message.info {
+  background-color: #d6eaf8;
+  color: #2874a6;
+  border: 1px solid #3498db;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #7f8c8d;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: white;
+  border-radius: 8px;
+  padding: 30px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal h2 {
+  margin-bottom: 20px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.member-item {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.member-info {
+  flex: 1;
+}
+
+.member-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.message-item {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+  margin-bottom: 10px;
+}
+
+.message-meta {
+  color: #7f8c8d;
+  font-size: 12px;
+  margin-bottom: 5px;
+}
+
+.rsvp-section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.rsvp-list h4 {
+  margin-top: 15px;
+  margin-bottom: 10px;
+  color: #7f8c8d;
+  text-transform: capitalize;
+}
+
+.auth-form {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+#user-info {
+  color: white;
+  padding: 8px 15px;
+}
+
+.htmx-indicator {
+  display: none;
+}
+
+.htmx-request .htmx-indicator {
+  display: inline;
+}
+
+.htmx-request.htmx-indicator {
+  display: inline;
+}

--- a/infrastructure/frontend/static/js/htmx-config.js
+++ b/infrastructure/frontend/static/js/htmx-config.js
@@ -1,0 +1,44 @@
+// HTMX Configuration for organize.dctech.events
+(function() {
+    'use strict';
+
+    // Wait for htmx to be available
+    document.addEventListener('DOMContentLoaded', function() {
+        // Configure HTMX to use the API URL from config
+        document.body.addEventListener('htmx:configRequest', function(event) {
+            // Prepend API URL to all relative paths starting with /api
+            if (event.detail.path.startsWith('/api')) {
+                event.detail.path = window.CONFIG.apiUrl.replace(/\/$/, '') + event.detail.path;
+            }
+
+            // Add auth token if user is authenticated
+            if (window.auth && window.auth.isAuthenticated()) {
+                window.auth.getIdToken((err, token) => {
+                    if (!err && token) {
+                        event.detail.headers['Authorization'] = `Bearer ${token}`;
+                    }
+                });
+            }
+        });
+
+        // Global error handler
+        document.body.addEventListener('htmx:responseError', function(event) {
+            console.error('HTMX request failed:', event.detail);
+            const target = event.detail.target;
+            if (target) {
+                target.innerHTML = '<div class="message error">Request failed. Please try again.</div>';
+            }
+        });
+
+        // Show loading indicators
+        document.body.addEventListener('htmx:beforeRequest', function(event) {
+            const indicators = document.querySelectorAll('.htmx-indicator');
+            indicators.forEach(ind => ind.style.display = 'inline');
+        });
+
+        document.body.addEventListener('htmx:afterRequest', function(event) {
+            const indicators = document.querySelectorAll('.htmx-indicator');
+            indicators.forEach(ind => ind.style.display = 'none');
+        });
+    });
+})();

--- a/infrastructure/lambda/deploy-static/index.js
+++ b/infrastructure/lambda/deploy-static/index.js
@@ -1,0 +1,258 @@
+/**
+ * Custom Resource Lambda for deploying static assets to S3
+ *
+ * This Lambda is triggered during CDK stack deployment to upload
+ * static assets (CSS, JS, images) to the S3 bucket.
+ */
+
+const { S3Client, PutObjectCommand, ListObjectsV2Command, DeleteObjectCommand } = require('@aws-sdk/client-s3');
+const { CloudFrontClient, CreateInvalidationCommand } = require('@aws-sdk/client-cloudfront');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const s3Client = new S3Client({});
+const cloudFrontClient = new CloudFrontClient({});
+
+const BUCKET_NAME = process.env.BUCKET_NAME;
+const DISTRIBUTION_ID = process.env.DISTRIBUTION_ID;
+const STATIC_ASSETS_PATH = '/var/task/static'; // Path where static assets are bundled
+
+/**
+ * Get MIME type from file extension
+ */
+function getMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.ttf': 'font/ttf',
+    '.eot': 'application/vnd.ms-fontobject',
+  };
+  return mimeTypes[ext] || 'application/octet-stream';
+}
+
+/**
+ * Recursively get all files in a directory
+ */
+function getAllFiles(dirPath, arrayOfFiles = []) {
+  const files = fs.readdirSync(dirPath);
+
+  files.forEach(file => {
+    const filePath = path.join(dirPath, file);
+    if (fs.statSync(filePath).isDirectory()) {
+      arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(filePath);
+    }
+  });
+
+  return arrayOfFiles;
+}
+
+/**
+ * Upload a file to S3
+ */
+async function uploadFile(filePath, bucketName) {
+  const fileContent = fs.readFileSync(filePath);
+  const relativePath = path.relative(STATIC_ASSETS_PATH, filePath);
+  const s3Key = `static/${relativePath}`;
+
+  const contentType = getMimeType(filePath);
+
+  console.log(`Uploading ${s3Key} (${contentType})`);
+
+  await s3Client.send(new PutObjectCommand({
+    Bucket: bucketName,
+    Key: s3Key,
+    Body: fileContent,
+    ContentType: contentType,
+    CacheControl: 'public, max-age=31536000', // 1 year for static assets
+  }));
+
+  return s3Key;
+}
+
+/**
+ * Delete all existing static assets from S3
+ */
+async function cleanupOldAssets(bucketName) {
+  console.log('Cleaning up old static assets...');
+
+  const listResponse = await s3Client.send(new ListObjectsV2Command({
+    Bucket: bucketName,
+    Prefix: 'static/',
+  }));
+
+  if (!listResponse.Contents || listResponse.Contents.length === 0) {
+    console.log('No old assets to clean up');
+    return;
+  }
+
+  console.log(`Deleting ${listResponse.Contents.length} old files...`);
+
+  for (const object of listResponse.Contents) {
+    await s3Client.send(new DeleteObjectCommand({
+      Bucket: bucketName,
+      Key: object.Key,
+    }));
+    console.log(`Deleted ${object.Key}`);
+  }
+}
+
+/**
+ * Deploy all static assets
+ */
+async function deployStaticAssets() {
+  console.log(`Deploying static assets to ${BUCKET_NAME}`);
+  console.log(`Static assets path: ${STATIC_ASSETS_PATH}`);
+
+  // Check if static assets directory exists
+  if (!fs.existsSync(STATIC_ASSETS_PATH)) {
+    console.log('No static assets directory found, skipping deployment');
+    return [];
+  }
+
+  // Clean up old assets first
+  await cleanupOldAssets(BUCKET_NAME);
+
+  // Get all files to upload
+  const files = getAllFiles(STATIC_ASSETS_PATH);
+  console.log(`Found ${files.length} files to upload`);
+
+  // Upload all files
+  const uploadedKeys = [];
+  for (const file of files) {
+    const key = await uploadFile(file, BUCKET_NAME);
+    uploadedKeys.push(key);
+  }
+
+  console.log(`Successfully uploaded ${uploadedKeys.length} files`);
+  return uploadedKeys;
+}
+
+/**
+ * Invalidate CloudFront cache
+ */
+async function invalidateCache(paths) {
+  if (!DISTRIBUTION_ID) {
+    console.log('No CloudFront distribution ID provided, skipping invalidation');
+    return;
+  }
+
+  console.log(`Invalidating CloudFront cache for ${paths.length} paths`);
+
+  const invalidationId = crypto.randomBytes(16).toString('hex');
+
+  await cloudFrontClient.send(new CreateInvalidationCommand({
+    DistributionId: DISTRIBUTION_ID,
+    InvalidationBatch: {
+      CallerReference: invalidationId,
+      Paths: {
+        Quantity: paths.length,
+        Items: paths.map(p => `/${p}`),
+      },
+    },
+  }));
+
+  console.log(`CloudFront invalidation created: ${invalidationId}`);
+}
+
+/**
+ * Send response to CloudFormation
+ */
+async function sendResponse(event, context, status, data = {}) {
+  const responseBody = JSON.stringify({
+    Status: status,
+    Reason: `See CloudWatch Log Stream: ${context.logStreamName}`,
+    PhysicalResourceId: context.logStreamName,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    Data: data,
+  });
+
+  console.log('Response body:', responseBody);
+
+  const https = require('https');
+  const url = require('url');
+
+  const parsedUrl = url.parse(event.ResponseURL);
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: 443,
+    path: parsedUrl.path,
+    method: 'PUT',
+    headers: {
+      'Content-Type': '',
+      'Content-Length': responseBody.length,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(options, (response) => {
+      console.log(`Status code: ${response.statusCode}`);
+      resolve();
+    });
+
+    request.on('error', (error) => {
+      console.error('sendResponse Error:', error);
+      reject(error);
+    });
+
+    request.write(responseBody);
+    request.end();
+  });
+}
+
+/**
+ * Main handler
+ */
+exports.handler = async (event, context) => {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  try {
+    const requestType = event.RequestType;
+
+    if (requestType === 'Delete') {
+      console.log('Delete request - cleaning up static assets');
+      await cleanupOldAssets(BUCKET_NAME);
+      await sendResponse(event, context, 'SUCCESS');
+      return;
+    }
+
+    if (requestType === 'Create' || requestType === 'Update') {
+      console.log(`${requestType} request - deploying static assets`);
+
+      const uploadedPaths = await deployStaticAssets();
+
+      // Invalidate CloudFront cache
+      if (uploadedPaths.length > 0) {
+        await invalidateCache(uploadedPaths);
+      }
+
+      await sendResponse(event, context, 'SUCCESS', {
+        FilesDeployed: uploadedPaths.length,
+      });
+      return;
+    }
+
+    throw new Error(`Unknown request type: ${requestType}`);
+  } catch (error) {
+    console.error('Error:', error);
+    await sendResponse(event, context, 'FAILED', {
+      Error: error.message,
+    });
+    throw error;
+  }
+};

--- a/infrastructure/lambda/deploy-static/package.json
+++ b/infrastructure/lambda/deploy-static/package.json
@@ -4,7 +4,7 @@
   "description": "Lambda function to deploy static assets to S3",
   "main": "index.js",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.0.0",
-    "@aws-sdk/client-cloudfront": "^3.0.0"
+    "@aws-sdk/client-s3": "^3.400.0",
+    "@aws-sdk/client-cloudfront": "^3.400.0"
   }
 }

--- a/infrastructure/lambda/deploy-static/package.json
+++ b/infrastructure/lambda/deploy-static/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "deploy-static-assets",
+  "version": "1.0.0",
+  "description": "Lambda function to deploy static assets to S3",
+  "main": "index.js",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/client-cloudfront": "^3.0.0"
+  }
+}

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -657,6 +657,10 @@ export class InfrastructureStack extends cdk.Stack {
 
     new cdk.CustomResource(this, 'DeployStaticResource', {
       serviceToken: deployStaticProvider.serviceToken,
+      properties: {
+        // Static asset changes are detected via Lambda function code hash
+        // No version property needed to avoid unnecessary redeployments
+      },
     });
 
     // ============================================


### PR DESCRIPTION
This commit consolidates the organize and next sites, eliminating transition-specific features and creating a unified platform:

**Feature flag removal:**
- Removed organize_integration_enabled, organize_groups_enabled, and organize_events_enabled flags from config.yaml
- These flags were for the old static site generator to optionally fetch data from organize.dctech.events
- No longer needed as next.dctech.events queries DynamoDB directly, which already contains both GitHub-synced and user-created content

**Build script cleanup:**
- Removed organize integration code from generate_month_data.py
- Eliminated fetch_organize_yaml() function and related code
- Removed unused urllib.request import
- The refresh Lambda already syncs all data to DynamoDB, so the static site builder doesn't need to fetch from organize

**Static assets consolidation:**
- Consolidated static assets under infrastructure/frontend/static/
- Added organize.css (copied from public/css/style.css)
- Added htmx-config.js for HTMX integration
- Kept main.css as the primary stylesheet (modern CSS with variables)

**Static asset deployment automation:**
- Created custom resource Lambda (deploy-static) that deploys static assets to S3 automatically when the CDK stack is updated
- Lambda bundles static assets and uploads to S3
- Invalidates CloudFront cache after deployment
- Eliminates manual upload steps

**Architecture benefits:**
- next.dctech.events now shows all groups and events from DynamoDB
- DynamoDB contains both GitHub-synced data and user-created content
- Single source of truth for all event/group data
- Automated deployment of static assets
- Cleaner codebase with eliminated transition code