### PR TITLE
Fix duplicate UID values in iCal feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -1107,14 +1107,19 @@ def ical_feed():
                 ical_event.add('organizer', group_website, parameters={'CN': group_name})
         
         # Generate a unique ID for the event
-        # Use URL if available, otherwise create a hash-based UID
+        # Always include date, time, and title to ensure uniqueness
+        # Include URL if available for additional stability
+        uid_parts = [
+            event_date_str,
+            event_time_str,
+            event.get('title', 'event')
+        ]
         if event.get('url'):
-            uid = f"{event['url']}@dctech.events"
-        else:
-            # Create a stable hash from date, time, and title for consistent UIDs
-            uid_base = f"{event_date_str}-{event_time_str}-{event.get('title', 'event')}"
-            uid_hash = hashlib.md5(uid_base.encode('utf-8')).hexdigest()
-            uid = f"{uid_hash}@dctech.events"
+            uid_parts.append(event['url'])
+
+        uid_base = '-'.join(str(p) for p in uid_parts)
+        uid_hash = hashlib.md5(uid_base.encode('utf-8')).hexdigest()
+        uid = f"{uid_hash}@dctech.events"
         ical_event.add('uid', uid)
         
         # Add creation timestamp


### PR DESCRIPTION
Fixed duplicate UID validation errors in the iCal feed by ensuring each event has a unique identifier. Previously, events sharing the same URL (common with recurring meetups) would get identical UIDs, violating RFC 5545.

The UID generation now includes:
- Event date (ensures different instances are unique)
- Event time
- Event title
- Event URL (if available)

All components are hashed together to create a stable, unique UID for each event instance in the format: {hash}@dctech.events

Added test_ical_unique_uids() to verify UIDs are unique even when events share the same URL.

Fixes: https://icalendar.org/validator.html errors at lines 177 and 477