### PR TITLE
Edit event: MongoDB Public Sector Summit 2026

### DIFF
--- a/_event_overrides/cfab1ba8c67c7c838db98d666f02a132.yaml
+++ b/_event_overrides/cfab1ba8c67c7c838db98d666f02a132.yaml
@@ -1,0 +1,9 @@
+title: "MongoDB Public Sector Summit 2026"
+date: '2026-01-27'
+time: '08:00'
+url: https://mongodbpublicsectorsummit.upgather.com/
+location: International Spy Museum, DC
+cost: 'Free'
+categories:
+  - vendor-conferences
+edited_by: rosskarchner


### PR DESCRIPTION
## Event Edit

**Original Event:** undefined
**Source:** unknown

### Changes
- **Title:** `(empty)` → `MongoDB Public Sector Summit 2026`
- **Date:** `(empty)` → `2026-01-27`
- **Time:** `(empty)` → `08:00`
- **URL:** `(empty)` → `https://mongodbpublicsectorsummit.upgather.com/`
- **Location:** `(empty)` → `International Spy Museum, DC`
- **Cost:** `(empty)` → `Free`
- **Categories:** `(none)` → `vendor-conferences`

---
This edit was submitted via the web form by @rosskarchner.