### PR TITLE
Edit event: MongoDB Public Sector Summit 2026

### DIFF
--- a/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
+++ b/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
@@ -2,7 +2,7 @@ title: "MongoDB Public Sector Summit 2026"
 date: '2026-01-27'
 time: '08:00'
 url: https://mongodbpublicsectorsummit.upgather.com/
-location: International Spy Museum, DC
+location: Washington, DC
 cost: 'Free'
 categories:
   - vendor-conferences

--- a/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
+++ b/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
@@ -1,8 +1,9 @@
-title: MongoDB Public Sector Summit 2026
+title: "MongoDB Public Sector Summit 2026"
 date: '2026-01-27'
 time: '08:00'
 url: https://mongodbpublicsectorsummit.upgather.com/
-location: International Spy Museum, Washington, DC
-cost: Free
-submitted_by: anonymous
-submitter_link: ''
+location: International Spy Museum, DC
+cost: 'Free'
+categories:
+  - vendor-conferences
+edited_by: rosskarchner


### PR DESCRIPTION
## Event Edit

**Original Event:** MongoDB Public Sector Summit 2026
**Source:** manual

### Changes
- **Location:** `International Spy Museum, Washington, DC` → `International Spy Museum, DC`
- **Categories:** `(none)` → `vendor-conferences`

---
This edit was submitted via the web form by @rosskarchner.