### PR TITLE
Assign ai category to 17 groups

### DIFF
--- a/_groups/ai-crypto-seminar.yaml
+++ b/_groups/ai-crypto-seminar.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/ai-crypto-seminar/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/ai-crypto-seminar/
+categories:
+  - ai

--- a/_groups/ai-safety-awareness-group-d-c.yaml
+++ b/_groups/ai-safety-awareness-group-d-c.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/ai-safety-awareness-group-d-c/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/ai-safety-awareness-group-d-c/
+categories:
+  - ai

--- a/_groups/ai_innovators_network.yaml
+++ b/_groups/ai_innovators_network.yaml
@@ -2,3 +2,5 @@ name: AI Innovators Network
 website: https://www.meetup.com/ai-innovators-network-tysons-meetup-dc-nova-md/
 ical: https://www.meetup.com/ai-innovators-network-tysons-meetup-dc-nova-md/events/ical/
 active: true
+categories:
+  - ai

--- a/_groups/artificial-intelligence-in-video-production.yaml
+++ b/_groups/artificial-intelligence-in-video-production.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/artificial-intelligence-in-video-production/events/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/artificial-intelligence-in-video-production/
+categories:
+  - ai

--- a/_groups/bethesda-open-source-ai.yaml
+++ b/_groups/bethesda-open-source-ai.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/bethesda-open-source-ai/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/bethesda-open-source-ai/
+categories:
+  - ai

--- a/_groups/data-ai-social-club.yaml
+++ b/_groups/data-ai-social-club.yaml
@@ -2,3 +2,5 @@ name: Data & AI Social Club
 website: https://www.meetup.com/data-ai-social-club/
 ical: https://www.meetup.com/data-ai-social-club/events/ical/
 active: true
+categories:
+  - ai

--- a/_groups/dc_ai_developers_group.yaml
+++ b/_groups/dc_ai_developers_group.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/dc-ai-llms/events/ical/
 active: true
 suppress_urls:
   - https://www.meetup.com/dc-ai-llms/events/307166051/
+categories:
+  - ai

--- a/_groups/dmvaigroup.yaml
+++ b/_groups/dmvaigroup.yaml
@@ -2,3 +2,5 @@ name: DMV Artificial Intelligence
 website: https://www.meetup.com/dmvaigroup
 ical: https://www.meetup.com/dmvaigroup/events/ical/
 active: true
+categories:
+  - ai

--- a/_groups/generative_ai_dc.yaml
+++ b/_groups/generative_ai_dc.yaml
@@ -2,3 +2,5 @@ name: Generative AI DC
 website: https://www.meetup.com/genaidc/
 ical: https://www.meetup.com/genaidc/events/ical/
 active: true
+categories:
+  - ai

--- a/_groups/ical-ai-discussion-club.yaml
+++ b/_groups/ical-ai-discussion-club.yaml
@@ -5,3 +5,5 @@ name: AI Discussion Club
 submitted_by: anonymous
 submitter_link: ''
 website: https://luma.com/ai-discussion-club
+categories:
+  - ai

--- a/_groups/ical-dc-data-ai-events.yaml
+++ b/_groups/ical-dc-data-ai-events.yaml
@@ -5,3 +5,5 @@ name: DC Data & AI Events
 submitted_by: anonymous
 submitter_link: ''
 website: https://luma.com/DC2
+categories:
+  - ai

--- a/_groups/learning-journey-ai.yaml
+++ b/_groups/learning-journey-ai.yaml
@@ -2,3 +2,5 @@ name: Learning Journey AI
 website: https://luma.com/calendar/cal-bgCwoSqr0HjJELt
 ical: https://api2.luma.com/ics/get?entity=calendar&id=cal-bgCwoSqr0HjJELt
 active: true
+categories:
+  - ai

--- a/_groups/meetup-ai-in-practice.yaml
+++ b/_groups/meetup-ai-in-practice.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/deploy-forward-ai-in-practice/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/deploy-forward-ai-in-practice/
+categories:
+  - ai

--- a/_groups/meetup-beyond-vibe-coding.yaml
+++ b/_groups/meetup-beyond-vibe-coding.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/beyond-vibe-coding/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/beyond-vibe-coding/
+categories:
+  - ai

--- a/_groups/meetup-drinking-about-ai.yaml
+++ b/_groups/meetup-drinking-about-ai.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/drinking-about-ai/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/drinking-about-ai
+categories:
+  - ai

--- a/_groups/nova-high-ai-cybersecurity-meetup-group.yaml
+++ b/_groups/nova-high-ai-cybersecurity-meetup-group.yaml
@@ -2,3 +2,5 @@ name: Nova High AI Cybersecurity Meetup Group
 website: https://www.meetup.com/nova-high-ai-cybersecurity-meetup-group
 ical: https://www.meetup.com/nova-high-ai-cybersecurity-meetup-group/events/ical/
 active: true
+categories:
+  - ai

--- a/_groups/where-humanity-meets-ai.yaml
+++ b/_groups/where-humanity-meets-ai.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/where-humanity-meets-ai/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/where-humanity-meets-ai/
+categories:
+  - ai


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **ai** to 17 group(s):

- AI Crypto Events
- AI Discussion Club
- AI in Practice
- AI Innovators Network
- AI Safety Awareness Group D.C.
- Artificial Intelligence - AI - in Video Production
- Bethesda Open Source AI
- Beyond Vibe Coding
- Data & AI Social Club
- DC AI Developers Group
- DC Data & AI Events
- DMV Artificial Intelligence
- Drinking about AI
- Generative AI DC
- Learning Journey AI
- Nova High AI Cybersecurity Meetup Group
- Where Humanity Meets AI

---
Submitted via web interface by @rosskarchner