### PR TITLE
Assign ux-design category to 4 groups

### DIFF
--- a/_groups/accessibility-dc.yaml
+++ b/_groups/accessibility-dc.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/accessibility-dc/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/accessibility-dc/
+categories:
+  - ux-design

--- a/_groups/design-thinking-dc.yaml
+++ b/_groups/design-thinking-dc.yaml
@@ -2,3 +2,5 @@ name: Design Thinking DC
 website: https://www.meetup.com/design-thinking-dc
 ical: https://www.meetup.com/design-thinking-dc/events/ical/
 active: true
+categories:
+  - ux-design

--- a/_groups/meetup-content-strategy-dc.yaml
+++ b/_groups/meetup-content-strategy-dc.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/content-strategy-dc/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/content-strategy-dc/
+categories:
+  - ux-design

--- a/_groups/washington_ux.yaml
+++ b/_groups/washington_ux.yaml
@@ -2,3 +2,5 @@ name: Washington User Experience Meetup Group
 website: https://www.meetup.com/washington-user-experience-meetup-group/
 ical: https://www.meetup.com/washington-user-experience-meetup-group/events/ical/
 active: true
+categories:
+  - ux-design


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **ux-design** to 4 group(s):

- Accessibility DC
- Content Strategy DC
- Design Thinking DC
- Washington User Experience Meetup Group

---
Submitted via web interface by @rosskarchner