### PR TITLE
Assign crypto category to 5 groups

### DIFF
--- a/_groups/ai-crypto-seminar.yaml
+++ b/_groups/ai-crypto-seminar.yaml
@@ -5,4 +5,4 @@ submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/ai-crypto-seminar/
 categories:
-  - ai
+  - crypto

--- a/_groups/bitcoin_district.yaml
+++ b/_groups/bitcoin_district.yaml
@@ -2,3 +2,5 @@ name: Bitcoin District
 website: https://www.meetup.com/bitcoin-district/
 ical: https://www.meetup.com/bitcoin-district/events/ical/
 active: true
+categories:
+  - crypto

--- a/_groups/dc_bit_devs.yaml
+++ b/_groups/dc_bit_devs.yaml
@@ -2,3 +2,5 @@ name: DC Bit Devs
 website: https://www.meetup.com/dc-bit-devs/
 ical: https://www.meetup.com/dc-bit-devs/events/ical/
 active: true
+categories:
+  - crypto

--- a/_groups/ical-dc-dao-calendar.yaml
+++ b/_groups/ical-dc-dao-calendar.yaml
@@ -5,3 +5,5 @@ name: DC DAO Calendar
 submitted_by: anonymous
 submitter_link: ''
 website: https://lu.ma/calendar/cal-tPiE7SLIv4FQ48E
+categories:
+  - crypto

--- a/_groups/meetup-midnight-blockchain-group-dc-md-va.yaml
+++ b/_groups/meetup-midnight-blockchain-group-dc-md-va.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/cardano-blockchain-dc-md-va/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/cardano-blockchain-dc-md-va/
+categories:
+  - crypto


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **crypto** to 5 group(s):

- AI Crypto Events
- Bitcoin District
- DC Bit Devs
- DC DAO Calendar
- Midnight Blockchain Group - DC/MD/VA

---
Submitted via web interface by @rosskarchner