### PR TITLE
Edit event: MongoDB Public Sector Summit 2026

### DIFF
--- a/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
+++ b/_single_events/2026-01-27-mongodb-public-sector-summit.yaml
@@ -5,5 +5,6 @@ url: https://mongodbpublicsectorsummit.upgather.com/
 location: Washington, DC
 cost: 'Free'
 categories:
+  - data
   - vendor-conferences
 edited_by: rosskarchner


### PR DESCRIPTION
## Event Edit

**Original Event:** MongoDB Public Sector Summit 2026
**Source:** manual

### Changes
- **Categories:** `vendor-conferences` → `data, vendor-conferences`

---
This edit was submitted via the web form by @rosskarchner.