### PR TITLE
Assign cybersecurity category to 7 groups

### DIFF
--- a/_groups/cyberwarriors.yaml
+++ b/_groups/cyberwarriors.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/cyberwarriors/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/cyberwarriors/
+categories:
+  - cybersecurity

--- a/_groups/dmv-api-security.yaml
+++ b/_groups/dmv-api-security.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/dmv-api-security/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/dmv-api-security/
+categories:
+  - cybersecurity

--- a/_groups/meetup-dmv-cybersecurity-meetup.yaml
+++ b/_groups/meetup-dmv-cybersecurity-meetup.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/wust-edu/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/wust-edu/
+categories:
+  - cybersecurity

--- a/_groups/meetup-loudoun-cybertech.yaml
+++ b/_groups/meetup-loudoun-cybertech.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/loudoun-cybertech/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/loudoun-cybertech/
+categories:
+  - cybersecurity

--- a/_groups/nova-beer-sec.yaml
+++ b/_groups/nova-beer-sec.yaml
@@ -2,3 +2,5 @@ name: NoVABeerSec
 website: https://www.meetup.com/nova-beer-sec
 ical: https://www.meetup.com/nova-beer-sec/events/ical/
 active: true
+categories:
+  - cybersecurity

--- a/_groups/nova-hackers.yaml
+++ b/_groups/nova-hackers.yaml
@@ -2,3 +2,5 @@ name: NoVA Hackers
 website: https://www.meetup.com/nova-hackers
 ical: https://www.meetup.com/nova-hackers/events/ical/
 active: true
+categories:
+  - cybersecurity

--- a/_groups/nova-high-ai-cybersecurity-meetup-group.yaml
+++ b/_groups/nova-high-ai-cybersecurity-meetup-group.yaml
@@ -3,4 +3,4 @@ website: https://www.meetup.com/nova-high-ai-cybersecurity-meetup-group
 ical: https://www.meetup.com/nova-high-ai-cybersecurity-meetup-group/events/ical/
 active: true
 categories:
-  - ai
+  - cybersecurity


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **cybersecurity** to 7 group(s):

- Loudoun CyberTech
- Nova High AI Cybersecurity Meetup Group
- Cyber Security Warriors Networking Group
- DMV Cybersecurity Meetup
- NoVABeerSec
- DMV API Security
- NoVA Hackers

---
Submitted via web interface by @rosskarchner