### PR TITLE
Assign cybersecurity category to 3 events

### DIFF
--- a/_single_events/2026-02-10-hack-the-railroad.yaml
+++ b/_single_events/2026-02-10-hack-the-railroad.yaml
@@ -7,3 +7,5 @@ submitter_link: ''
 time: 08:00
 title: Defend the Railroad
 url: https://thetac.tech/defend-the-railroad-cyber-security-collaborative/
+categories:
+  - cybersecurity

--- a/_single_events/2026-04-16-isaca-future-tech-dc.yaml
+++ b/_single_events/2026-04-16-isaca-future-tech-dc.yaml
@@ -6,3 +6,5 @@ location: Arlington, VA
 cost: Check website for pricing
 submitted_by: anonymous
 submitter_link: ''
+categories:
+  - cybersecurity

--- a/_single_events/cybertalks_2026.yaml
+++ b/_single_events/cybertalks_2026.yaml
@@ -3,3 +3,5 @@ date: '2026-02-19'
 time: 08:00
 url: https://www.eventbrite.com/e/cybertalks-2026-registration-1230193976299
 location: Washington, DC
+categories:
+  - cybersecurity


### PR DESCRIPTION
## Bulk Category Assignment

Assigned category **cybersecurity** to 3 event(s):

- Defend the Railroad
- CyberTalks 2026
- ISACA Future Tech DC 2026

---
Submitted via web interface by @rosskarchner