### PR TITLE
Assign social category to 5 groups

### DIFF
--- a/_groups/antinetworkers.yaml
+++ b/_groups/antinetworkers.yaml
@@ -3,3 +3,5 @@ website: https://lu.ma/antinetworkers
 ical: https://api.lu.ma/ics/get?entity=calendar&id=cal-JKay5R7w9EMOAVl
 fallback_url: https://lu.ma/antinetworkers
 active: true
+categories:
+  - social

--- a/_groups/dc_tech_parties.yaml
+++ b/_groups/dc_tech_parties.yaml
@@ -3,3 +3,5 @@ website: https://www.dctechparties.com/
 ical: https://api.lu.ma/ics/get?entity=calendar&id=cal-mxkaa29dR0YNlaJ
 fallback_url: https://lu.ma/dctechparties
 active: true
+categories:
+  - social

--- a/_groups/ical-girlies-in-tech.yaml
+++ b/_groups/ical-girlies-in-tech.yaml
@@ -5,3 +5,5 @@ name: Girlies in Tech
 submitted_by: anonymous
 submitter_link: ''
 website: https://luma.com/girliesintechdinner?k=c
+categories:
+  - social

--- a/_groups/meetup-women-and-gender-expansive-coders-dc---wgxc-dc.yaml
+++ b/_groups/meetup-women-and-gender-expansive-coders-dc---wgxc-dc.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/women-and-gender-expansive-coders-dc-wgxc-dc/events
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/women-and-gender-expansive-coders-dc-wgxc-dc/
+categories:
+  - social

--- a/_groups/nerd_dinner_tysons.yaml
+++ b/_groups/nerd_dinner_tysons.yaml
@@ -2,3 +2,5 @@ name: Nerd Dinner Tysons
 website: https://www.meetup.com/nerd-dinner-tysons/
 ical: https://www.meetup.com/Nerd-Dinner-Tysons/events/ical/
 active: true
+categories:
+  - social


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **social** to 5 group(s):

- Anti-Networking Networking Club
- DC Tech Parties
- Girlies in Tech
- Nerd Dinner Tysons
- Women and Gender eXpansive Coders DC - WGXC DC

---
Submitted via web interface by @rosskarchner