### PR TITLE
Assign open-source-community category to 9 groups

### DIFF
--- a/_groups/dc-area-apache-airflow-meetup.yaml
+++ b/_groups/dc-area-apache-airflow-meetup.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/dc-area-apache-airflow-meetup/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/dc-area-apache-airflow-meetup/
+categories:
+  - open-source-community

--- a/_groups/dc_kubernetes_meetup.yaml
+++ b/_groups/dc_kubernetes_meetup.yaml
@@ -2,3 +2,5 @@ name: DC Kubernetes Meetup
 website: https://www.meetup.com/dc-kubernetes-meetup/
 ical: https://www.meetup.com/DC-Kubernetes-Meetup/events/ical/
 active: true
+categories:
+  - open-source-community

--- a/_groups/dc_pyladies.yaml
+++ b/_groups/dc_pyladies.yaml
@@ -2,3 +2,5 @@ name: DC PyLadies
 website: https://www.meetup.com/dc-pyladies/
 ical: https://www.meetup.com/dc-pyladies/events/ical/
 active: true
+categories:
+  - open-source-community

--- a/_groups/dc_python_dojo.yaml
+++ b/_groups/dc_python_dojo.yaml
@@ -5,3 +5,5 @@ fallback_url: https://lu.ma/pydistrict
 active: true
 suppress_urls:
   - https://lu.ma/e/evt-PrnKuOUHph8Fgjg
+categories:
+  - open-source-community

--- a/_groups/golang-reston.yaml
+++ b/_groups/golang-reston.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/golang-reston/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/golang-reston/
+categories:
+  - open-source-community

--- a/_groups/grafana-and-friends-dc.yaml
+++ b/_groups/grafana-and-friends-dc.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/grafana-and-friends-dc/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/grafana-and-friends-dc/
+categories:
+  - open-source-community

--- a/_groups/meetup-dc-area-drupal-meetup-group.yaml
+++ b/_groups/meetup-dc-area-drupal-meetup-group.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/drupal-dc/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/drupal-dc/
+categories:
+  - open-source-community

--- a/_groups/northern_virginia_linux_users_group_novalug.yaml
+++ b/_groups/northern_virginia_linux_users_group_novalug.yaml
@@ -3,3 +3,5 @@ website: https://novalug.org/
 ical: https://mobilizon.us/@novalug/feed/ics
 active: true
 scan_for_metadata: false
+categories:
+  - open-source-community

--- a/_groups/the-argo-meetup-washington-dc.yaml
+++ b/_groups/the-argo-meetup-washington-dc.yaml
@@ -4,3 +4,5 @@ ical: https://www.meetup.com/the-argo-meetup-washington-dc/events/ical/
 submitted_by: anonymous
 submitter_link: ''
 website: https://www.meetup.com/the-argo-meetup-washington-dc/
+categories:
+  - open-source-community


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **open-source-community** to 9 group(s):

- DC Area Apache Airflow Meetup
- DC Area Drupal Meetup Group
- DC Kubernetes Meetup
- DC PyLadies
- DC Python Dojo
- Grafana & Friends DC
- Golang Reston
- Meetup for Argo - Washington DC
- Northern Virginia Linux Users Group (NoVaLUG)

---
Submitted via web interface by @rosskarchner