### PR TITLE
Assign gaming category to 3 groups

### DIFF
--- a/_groups/games-for-agililty-learning-engagement.yaml
+++ b/_groups/games-for-agililty-learning-engagement.yaml
@@ -2,3 +2,5 @@ name: Games for Agility, Learning, & Engagement
 website: https://www.meetup.com/games-for-agililty-learning-engagement
 ical: https://www.meetup.com/games-for-agililty-learning-engagement/events/ical/
 active: true
+categories:
+  - gaming

--- a/_groups/igda_dc.yaml
+++ b/_groups/igda_dc.yaml
@@ -2,3 +2,5 @@ name: IGDA DC
 website: https://www.meetup.com/igda-dc/
 ical: https://www.meetup.com/igda-dc/events/ical/
 active: true
+categories:
+  - gaming

--- a/_groups/nova_game_developers.yaml
+++ b/_groups/nova_game_developers.yaml
@@ -2,3 +2,5 @@ name: NOVA Game Developers
 website: https://www.meetup.com/novagamedevs/
 ical: https://www.meetup.com/novagamedevs/events/ical/
 active: true
+categories:
+  - gaming


### PR DESCRIPTION
## Bulk Group Categorization

Assigned category **gaming** to 3 group(s):

- Games for Agility, Learning, & Engagement
- IGDA DC
- NOVA Game Developers

---
Submitted via web interface by @rosskarchner