### PR TITLE
Hide event: 2026 Tech Summit &#8212; CANCELLED

### DIFF
--- a/_event_overrides/2aeea25c160004875fe52e749b2716d4.yaml
+++ b/_event_overrides/2aeea25c160004875fe52e749b2716d4.yaml
@@ -1,0 +1,1 @@
+hidden: true


### PR DESCRIPTION
## Hide Event

**Event:** 2026 Tech Summit &#8212; CANCELLED
**Date:** 2026-02-18
**Source:** ical
**Group:** AFCEA
**File:** `_event_overrides/2aeea25c160004875fe52e749b2716d4.yaml`

This PR marks an iCal event as hidden. The event will no longer appear on the calendar.

---
Submitted via web interface by @rosskarchner