### PR TITLE
Delete event: AFCEA DC Tech Summit 2026

### DIFF
--- a/_single_events/2026-02-19-afcea-dc-tech-summit.yaml
+++ b/_single_events/2026-02-19-afcea-dc-tech-summit.yaml
@@ -1,8 +1,0 @@
-cost: Check website for pricing
-date: '2026-02-19'
-end_date: '2026-02-19'
-location: 'Reston, VA'
-submitted_by: anonymous
-submitter_link: ''
-title: AFCEA DC Tech Summit 2026
-url: https://dc.afceachapters.org/


### PR DESCRIPTION
## Delete Manual Event

**Event:** AFCEA DC Tech Summit 2026
**Date:** 2026-02-19
**File:** `_single_events/2026-02-19-afcea-dc-tech-summit.yaml`

This PR deletes a manually added event from the calendar.

---
Submitted via web interface by @rosskarchner