### PR TITLE
Edit event: Defense IT Summit 2026

### DIFF
--- a/_single_events/2026-02-26-defense-it-summit.yaml
+++ b/_single_events/2026-02-26-defense-it-summit.yaml
@@ -1,7 +1,9 @@
-title: Defense IT Summit 2026
+title: "Defense IT Summit 2026"
 date: '2026-02-26'
 url: https://govciomedia.com/defense-it-summit-2026/
 location: Arlington, VA
-cost: Check website for pricing
-submitted_by: anonymous
-submitter_link: ''
+end_date: '2026-02-26'
+cost: 'Check website for pricing'
+categories:
+  - govtech
+edited_by: rosskarchner


### PR DESCRIPTION
## Event Edit

**Original Event:** Defense IT Summit 2026
**Source:** manual

### Changes
- **Categories:** `(none)` → `govtech`

---
This edit was submitted via the web form by @rosskarchner.