### PR TITLE
Fix event tracking by excluding upcoming-history/ from S3 sync --delete

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Sync built site to S3 bucket
         id: s3-sync
         run: |
-          aws s3 sync build/ s3://${{ env.S3_BUCKET }}/ --delete
+          aws s3 sync build/ s3://${{ env.S3_BUCKET }}/ --delete --exclude 'upcoming-history/*'
         continue-on-error: true
 
       - name: Retry S3 sync on failure
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "Retrying S3 sync..."
           sleep 5
-          aws s3 sync build/ s3://${{ env.S3_BUCKET }}/ --delete
+          aws s3 sync build/ s3://${{ env.S3_BUCKET }}/ --delete --exclude 'upcoming-history/*'
 
       - name: Invalidate CloudFront cache
         id: cf-invalidate


### PR DESCRIPTION
The S3 sync step was using --delete which removed all files in S3
not present in the build/ directory. This wiped out the
upcoming-history/ prefix (latest.yaml and metadata.json) on every
deployment, causing track_events.py to find no previous version and
treat all events as new every time.

https://claude.ai/code/session_01FLLvPzZA41w5KMLxKQxwGx