### PR TITLE
Fix subscriber list truncated at 50 due to missing SES pagination

### DIFF
--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -268,9 +268,16 @@ def get_subscribers_json(event, jinja_env):
 
     try:
         sesv2 = boto3.client('sesv2', region_name='us-east-1')
-        response = sesv2.list_contacts(ContactListName='newsletters')
-        
-        contacts = response.get('Contacts', [])
+        contacts = []
+        kwargs = {'ContactListName': 'newsletters'}
+        while True:
+            response = sesv2.list_contacts(**kwargs)
+            contacts.extend(response.get('Contacts', []))
+            next_token = response.get('NextToken')
+            if not next_token:
+                break
+            kwargs['NextToken'] = next_token
+
         # Sort by LastUpdatedTimestamp (newest first)
         contacts.sort(key=lambda x: x.get('LastUpdatedTimestamp', ''), reverse=True)
         

--- a/test_app.py
+++ b/test_app.py
@@ -178,31 +178,31 @@ class TestApp(unittest.TestCase):
         import os
         import yaml
         
-        # Create test data directory
-        data_dir = '_data'
+        # Create test data directory (site-scoped: _data/dctech/)
+        data_dir = os.path.join('_data', 'dctech')
         os.makedirs(data_dir, exist_ok=True)
         test_file = os.path.join(data_dir, 'stats.yaml')
-        
+
         test_stats = {
             'upcoming_events': 42,
             'active_groups': 10
         }
-        
+
         try:
             # Test with no stats file
             if os.path.exists(test_file):
                 os.remove(test_file)
             stats = get_stats()
             self.assertEqual(stats, {})
-            
+
             # Test with stats file
             with open(test_file, 'w') as f:
                 yaml.dump(test_stats, f)
-            
+
             stats = get_stats()
             self.assertEqual(stats['upcoming_events'], 42)
             self.assertEqual(stats['active_groups'], 10)
-            
+
         finally:
             # Cleanup
             if os.path.exists(test_file):
@@ -615,9 +615,9 @@ class TestApp(unittest.TestCase):
         data_dir = '_data'
         os.makedirs(data_dir, exist_ok=True)
         test_file = os.path.join(data_dir, 'upcoming.yaml')
-        
-        # Create test group directory and files
-        groups_dir = '_groups'
+
+        # Create test group directory (site-scoped: dctech/_groups/)
+        groups_dir = os.path.join('dctech', '_groups')
         os.makedirs(groups_dir, exist_ok=True)
         group_file = os.path.join(groups_dir, 'test-tech-group.yaml')
         
@@ -651,14 +651,14 @@ class TestApp(unittest.TestCase):
         }
         
         try:
-            # Write test data
+            # Write test data (mock reads _data/upcoming.yaml)
             with open(test_file, 'w') as f:
                 yaml.dump(test_events, f)
-            
+
             # Write test group
             with open(group_file, 'w') as f:
                 yaml.dump(test_group, f)
-            
+
             # Get iCal feed
             response = client.get('/events.ics')
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
list_contacts returns at most 50 contacts per call; loop over NextToken to collect all pages before sorting and returning the full list.

https://claude.ai/code/session_01H7XgeT6PLWvxknZbGcGyMB