### PR TITLE
fix: drop relative --output-dir so calgen builds to the correct directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,14 +99,14 @@ jobs:
         run: calgen pipeline
 
       - name: Build Static Site
-        run: calgen build --output-dir build/dctech
+        run: calgen build
 
       - name: Prepare GitHub Pages artifact
         run: |
           rm -rf pages
           mkdir -p pages
           mkdir -p pages/edit
-          cp -a build/dctech/. pages/
+          cp -a build/. pages/
           cp -a frontends/edit/. pages/edit/
           printf 'dctech.events\n' > pages/CNAME
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ generate-month-data: refresh-calendars
 	$(CALGEN) pipeline
 
 freeze: generate-month-data
-	$(CALGEN) build --output-dir build/dctech
+	$(CALGEN) build
 
 validate:
 	python .github/scripts/validate_all_existing.py

--- a/freeze.py
+++ b/freeze.py
@@ -3,4 +3,4 @@
 from calgen.freeze import main
 
 if __name__ == '__main__':
-    main(output_dir='build/dctech')
+    main()


### PR DESCRIPTION
## Summary

- **Root cause:** Flask-Frozen resolves `FREEZER_DESTINATION` against `app.root_path` (the calgen package directory inside site-packages), not the process CWD. Passing `--output-dir build/dctech` as a relative path caused the frozen site to be written into the calgen package tree rather than the project's `build/` directory, so the subsequent `cp -a build/dctech/. pages/` step in CI had nothing to copy.
- **Fix:** Remove `--output-dir build/dctech` everywhere so calgen uses its default: `os.path.join(site_dir, 'build')`, which is an absolute path that Flask-Frozen handles correctly. Update the `cp` step in deploy.yml to match (`build/` instead of `build/dctech/`).
- Files changed: `.github/workflows/deploy.yml`, `Makefile`, `freeze.py`

## Test plan

- [ ] Verify `calgen build` (no `--output-dir`) writes files to `<repo>/build/` locally
- [ ] Confirm deploy workflow's `cp -a build/. pages/` step succeeds after the build step
- [ ] Check that the deployed GitHub Pages site renders correctly

https://claude.ai/code/session_01KwJu8SXgBsDhDk2GZXGZ6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwJu8SXgBsDhDk2GZXGZ6R)_