### PR TITLE
feat: dynamic QA agent firewall allowlist + CI auto-compile

### DIFF
--- a/.github/workflows/calendar-qc.lock.yml
+++ b/.github/workflows/calendar-qc.lock.yml
@@ -770,7 +770,171 @@ jobs:
           export GH_AW_NODE_BIN
           export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
-          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.49/awf-config.schema.json","network":{"allowDomains":["*.pythonhosted.org","anaconda.org","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","binstar.org","bootstrap.pypa.io","conda.anaconda.org","conda.binstar.org","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","eventbrite.com","files.pythonhosted.org","github.com","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lu.ma","luma.co","meetup.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","pip.pypa.io","ppa.launchpad.net","pypi.org","pypi.python.org","raw.githubusercontent.com","registry.npmjs.org","repo.anaconda.com","repo.continuum.io","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.eventbrite.com","www.googleapis.com","www.lu.ma","www.meetup.com"]},"apiProxy":{"enabled":true,"enableTokenSteering":true,"maxRuns":500,"maxEffectiveTokens":25000000,"models":{"agent":["sonnet-6x","gpt-5.4","gpt-5","gemini-pro","haiku","any"],"any":["copilot/*","anthropic/*","openai/*","google/*","gemini/*"],"auto":["large"],"claude":["agent","sonnet-6x","haiku","any"],"codex":["agent","gpt-5-codex","gpt-5","any"],"coding":["copilot/gpt-5*codex*","openai/gpt-5*codex*","gpt-5-codex"],"copilot":["agent","gpt-5.4","sonnet","gpt-5","any"],"deep-research":["copilot/deep-research*","copilot/o3-deep-research*","copilot/o4-mini-deep-research*","google/deep-research*","gemini/deep-research*","openai/o3-deep-research*","openai/o4-mini-deep-research*"],"gemini":["agent","gemini-pro","gemini-flash","any"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*","gemini/gemini-*flash*"],"gemini-flash-lite":["copilot/gemini-*flash*lite*","google/gemini-*flash*lite*","gemini/gemini-*flash*lite*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*","gemini/gemini-*pro*"],"gemma":["copilot/gemma*","google/gemma*","gemini/gemma*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash-lite","copilot/raptor*mini*"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"],"sonnet-6x":["copilot/*sonnet-4.5*","copilot/*sonnet-4-5*","anthropic/*sonnet-4.5*","anthropic/*sonnet-4-5*","copilot/*sonnet-3.7*","copilot/*sonnet-3-7*","anthropic/*sonnet-3.7*","anthropic/*sonnet-3-7*","copilot/*sonnet-3.5*","copilot/*sonnet-3-5*","anthropic/*sonnet-3.5*","anthropic/*sonnet-3-5*"],"vision":["copilot/gemini-*image*","gemini/gemini-*image*","copilot/gemini-*flash*","gemini/gemini-*flash*"]}},"container":{"imageTag":"0.25.49"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json"
+          python3 - <<'GH_AW_PYEOF'
+          import glob
+          import json
+          import os
+          import re
+          from urllib.parse import urlparse
+
+          BASE_ALLOW_DOMAINS = [
+              "*.pythonhosted.org",
+              "anaconda.org",
+              "api.business.githubcopilot.com",
+              "api.enterprise.githubcopilot.com",
+              "api.github.com",
+              "api.githubcopilot.com",
+              "api.individual.githubcopilot.com",
+              "api.snapcraft.io",
+              "archive.ubuntu.com",
+              "azure.archive.ubuntu.com",
+              "binstar.org",
+              "bootstrap.pypa.io",
+              "conda.anaconda.org",
+              "conda.binstar.org",
+              "crl.geotrust.com",
+              "crl.globalsign.com",
+              "crl.identrust.com",
+              "crl.sectigo.com",
+              "crl.thawte.com",
+              "crl.usertrust.com",
+              "crl.verisign.com",
+              "crl3.digicert.com",
+              "crl4.digicert.com",
+              "crls.ssl.com",
+              "eventbrite.com",
+              "files.pythonhosted.org",
+              "github.com",
+              "host.docker.internal",
+              "json-schema.org",
+              "json.schemastore.org",
+              "keyserver.ubuntu.com",
+              "lu.ma",
+              "luma.co",
+              "meetup.com",
+              "ocsp.digicert.com",
+              "ocsp.geotrust.com",
+              "ocsp.globalsign.com",
+              "ocsp.identrust.com",
+              "ocsp.sectigo.com",
+              "ocsp.ssl.com",
+              "ocsp.thawte.com",
+              "ocsp.usertrust.com",
+              "ocsp.verisign.com",
+              "packagecloud.io",
+              "packages.cloud.google.com",
+              "packages.microsoft.com",
+              "pip.pypa.io",
+              "ppa.launchpad.net",
+              "pypi.org",
+              "pypi.python.org",
+              "raw.githubusercontent.com",
+              "registry.npmjs.org",
+              "repo.anaconda.com",
+              "repo.continuum.io",
+              "s.symcb.com",
+              "s.symcd.com",
+              "security.ubuntu.com",
+              "telemetry.enterprise.githubcopilot.com",
+              "ts-crl.ws.symantec.com",
+              "ts-ocsp.ws.symantec.com",
+              "www.eventbrite.com",
+              "www.googleapis.com",
+              "www.lu.ma",
+              "www.meetup.com",
+          ]
+
+          URL_REGEX = re.compile(r"https?://[^\s'\"<>)\]]+", re.IGNORECASE)
+          harvested_domains = set(BASE_ALLOW_DOMAINS)
+
+          def add_domain(hostname):
+              if not hostname:
+                  return
+              hostname = hostname.strip().lower().strip(".")
+              if not hostname:
+                  return
+              harvested_domains.add(hostname)
+              if hostname.startswith("www.") and len(hostname) > 4:
+                  harvested_domains.add(hostname[4:])
+
+          for pattern in ("_groups/*.yaml", "_single_events/*.yaml"):
+              for file_path in glob.glob(pattern):
+                  with open(file_path, encoding="utf-8") as source_file:
+                      for raw_url in URL_REGEX.findall(source_file.read()):
+                          add_domain(urlparse(raw_url.rstrip(".,;:")).hostname)
+
+          config = {
+              "$schema": "https://github.com/github/gh-aw-firewall/releases/download/v0.25.49/awf-config.schema.json",
+              "network": {"allowDomains": sorted(harvested_domains)},
+              "apiProxy": {
+                  "enabled": True,
+                  "enableTokenSteering": True,
+                  "maxRuns": 500,
+                  "maxEffectiveTokens": 25000000,
+                  "models": {
+                      "agent": ["sonnet-6x", "gpt-5.4", "gpt-5", "gemini-pro", "haiku", "any"],
+                      "any": ["copilot/*", "anthropic/*", "openai/*", "google/*", "gemini/*"],
+                      "auto": ["large"],
+                      "claude": ["agent", "sonnet-6x", "haiku", "any"],
+                      "codex": ["agent", "gpt-5-codex", "gpt-5", "any"],
+                      "coding": ["copilot/gpt-5*codex*", "openai/gpt-5*codex*", "gpt-5-codex"],
+                      "copilot": ["agent", "gpt-5.4", "sonnet", "gpt-5", "any"],
+                      "deep-research": [
+                          "copilot/deep-research*",
+                          "copilot/o3-deep-research*",
+                          "copilot/o4-mini-deep-research*",
+                          "google/deep-research*",
+                          "gemini/deep-research*",
+                          "openai/o3-deep-research*",
+                          "openai/o4-mini-deep-research*",
+                      ],
+                      "gemini": ["agent", "gemini-pro", "gemini-flash", "any"],
+                      "gemini-flash": ["copilot/gemini-*flash*", "google/gemini-*flash*", "gemini/gemini-*flash*"],
+                      "gemini-flash-lite": [
+                          "copilot/gemini-*flash*lite*",
+                          "google/gemini-*flash*lite*",
+                          "gemini/gemini-*flash*lite*",
+                      ],
+                      "gemini-pro": ["copilot/gemini-*pro*", "google/gemini-*pro*", "gemini/gemini-*pro*"],
+                      "gemma": ["copilot/gemma*", "google/gemma*", "gemini/gemma*"],
+                      "gpt-4.1": ["copilot/gpt-4.1*", "openai/gpt-4.1*"],
+                      "gpt-5": ["copilot/gpt-5*", "openai/gpt-5*"],
+                      "gpt-5-codex": ["copilot/gpt-5*codex*", "openai/gpt-5*codex*"],
+                      "gpt-5-mini": ["copilot/gpt-5*mini*", "openai/gpt-5*mini*"],
+                      "gpt-5-nano": ["copilot/gpt-5*nano*", "openai/gpt-5*nano*"],
+                      "gpt-5-pro": ["copilot/gpt-5*pro*", "openai/gpt-5*pro*"],
+                      "haiku": ["copilot/*haiku*", "anthropic/*haiku*"],
+                      "large": ["sonnet", "gpt-5-pro", "gpt-5", "gemini-pro"],
+                      "mini": ["haiku", "gpt-5-mini", "gpt-5-nano", "gemini-flash-lite", "copilot/raptor*mini*"],
+                      "opus": ["copilot/*opus*", "anthropic/*opus*"],
+                      "reasoning": ["copilot/o1*", "copilot/o3*", "copilot/o4*", "openai/o1*", "openai/o3*", "openai/o4*"],
+                      "small": ["mini"],
+                      "sonnet": ["copilot/*sonnet*", "anthropic/*sonnet*"],
+                      "sonnet-6x": [
+                          "copilot/*sonnet-4.5*",
+                          "copilot/*sonnet-4-5*",
+                          "anthropic/*sonnet-4.5*",
+                          "anthropic/*sonnet-4-5*",
+                          "copilot/*sonnet-3.7*",
+                          "copilot/*sonnet-3-7*",
+                          "anthropic/*sonnet-3.7*",
+                          "anthropic/*sonnet-3-7*",
+                          "copilot/*sonnet-3.5*",
+                          "copilot/*sonnet-3-5*",
+                          "anthropic/*sonnet-3.5*",
+                          "anthropic/*sonnet-3-5*",
+                      ],
+                      "vision": ["copilot/gemini-*image*", "gemini/gemini-*image*", "copilot/gemini-*flash*", "gemini/gemini-*flash*"],
+                  },
+              },
+              "container": {"imageTag": "0.25.49"},
+          }
+
+          awf_config_path = os.path.join(os.environ["RUNNER_TEMP"], "gh-aw", "awf-config.json")
+          with open(awf_config_path, "w", encoding="utf-8") as target_file:
+              json.dump(config, target_file, separators=(",", ":"))
+          print(f"Harvested {len(harvested_domains)} firewall domains from groups and single events")
+          GH_AW_PYEOF
           cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS=""
           if [[ "${DOCKER_HOST:-}" =~ ^tcp:// ]]; then
@@ -1579,4 +1743,3 @@ jobs:
         with:
           key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
           path: /tmp/gh-aw/cache-memory
-

--- a/.github/workflows/compile-agentic-lock.yml
+++ b/.github/workflows/compile-agentic-lock.yml
@@ -1,0 +1,51 @@
+name: Compile Agentic Workflow Lockfiles
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*.md'
+      - '.github/workflows/*.lock.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: compile-agentic-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-agentic-lockfiles:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+
+      - name: Ensure gh-aw is available
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh aw version || gh extension install github/gh-aw
+
+      - name: Compile workflows
+        run: gh aw compile --approve
+
+      - name: Commit regenerated lockfiles
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          if [ -z "$(git status --porcelain -- '.github/workflows/*.lock.yml')" ]; then
+            echo "No lockfile changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -- '.github/workflows/*.lock.yml'
+          git commit -m "chore: recompile agentic workflow lockfiles"
+          git push origin "HEAD:${BRANCH_NAME}"


### PR DESCRIPTION
## Why

The QA agent's AWF firewall allowlist was hardcoded in `calendar-qc.lock.yml`. When a new group or single event was added with a URL on a new domain, the agent couldn't fetch that site until someone manually updated the allowlist and re-ran `gh aw compile` locally.

## What changed

### Runtime allowlist harvesting (`calendar-qc.lock.yml`)

The "Execute GitHub Copilot CLI" step now runs a Python snippet at workflow runtime that:
1. Scans all `_groups/*.yaml` and `_single_events/*.yaml` files for `http/https` URLs
2. Extracts and normalizes hostnames (collapsing `www.example.com` -> `example.com` too)
3. Merges them with the existing curated baseline list
4. Writes the combined sorted set to `awf-config.json` before AWF launches

New event sources are picked up automatically on the next weekly run -- no manual edits or recompile needed.

### CI auto-compile (`.github/workflows/compile-agentic-lock.yml`)

Adds a new workflow that runs `gh aw compile --approve` on any PR that touches `.github/workflows/*.md` or `.github/workflows/*.lock.yml`, then auto-commits regenerated lockfiles back to the PR branch. This removes the need to compile locally when editing agentic workflow markdown.

## Notes

- The detection job's firewall config (used for threat detection, not QA) is intentionally left with its narrow hardcoded list -- it should not have broad outbound access.
- `compile-agentic-lock.yml` only auto-pushes for branches in this repo, not forks, so external contributors aren't affected.