### PR TITLE
Make calendar QC PRs non-draft

### DIFF
--- a/.github/workflows/calendar-qc.md
+++ b/.github/workflows/calendar-qc.md
@@ -221,7 +221,8 @@ After reviewing all in-scope events:
 1. Append every reviewed GUID (regardless of whether you found issues) to `/tmp/gh-aw/cache-memory/reviewed.json`. Create the file if it doesn't exist. Use JSON array format.
 
 2. **If you modified or created any overlay files**:
-   - Create a pull request titled `[calendar-qc] Weekly quality control fixes`
+   - Create a non-draft pull request titled `[calendar-qc] Weekly quality control fixes`
+     so it opens ready for auto-merge
    - PR body should list each fix with a brief reason, grouped by type:
      - **Duplicates (N)**: `{title}` — `{duplicate-guid}` → canonical `{canonical-guid}`
      - **Hidden (N)**: `{title}` — reason


### PR DESCRIPTION
Calendar QC PRs were being opened as draft, which prevented the auto-merge workflow from merging them immediately.

This change updates the workflow instructions so future calendar QC runs open a normal PR ready for auto-merge.